### PR TITLE
fix: removed duplicate events from events page

### DIFF
--- a/pages/eventsPage.tsx
+++ b/pages/eventsPage.tsx
@@ -47,6 +47,16 @@ export default function Events({ events }: Props): JSX.Element {
     );
   });
 
+  const uniqueEvents = Array.from(
+    // filters out identical events, ignoring "id" field
+    new Map(
+      filteredEvents.map((event) => [
+        JSON.stringify({ ...event, id: undefined }),
+        event,
+      ]),
+    ).values(),
+  );
+
   return (
     <MainLayout>
       <div className={styles.main}>
@@ -59,7 +69,7 @@ export default function Events({ events }: Props): JSX.Element {
               <h4 className={styles.message}>Stay tuned for more events!</h4>
             </div>
           )}
-          {filteredEvents.map((event, index) => {
+          {uniqueEvents.map((event, index) => {
             const start = format(new Date(event.start), 'h:mma');
             const end = format(new Date(event.end), 'h:mma');
             const startDate = format(new Date(event.start), 'E MMM d');


### PR DESCRIPTION
### Resolves [issue #7](https://github.com/uclaacm/board-official-website/issues/7) from board repo

Duplicate events were showing up on the events page due to duplicate events on ACM Newsletter Spreadsheet (some committees want to push notifs for event weeks prior to event).

Fix: filter out duplicates in the events list, while ignoring event 'id's